### PR TITLE
Support Windows on ARM64

### DIFF
--- a/_custom_build/checksums.cfg
+++ b/_custom_build/checksums.cfg
@@ -23,6 +23,11 @@ file_name = actionlint_1.6.25_windows_amd64.zip
 checksum = 8f572a723f362f2ab05777aad0c85322fecf130e6ff0ca8ca0a6fb3a3414ac1b
 url = https://github.com/rhysd/actionlint/releases/download/v1.6.25/actionlint_1.6.25_windows_amd64.zip
 
+[win32-ARM64]
+file_name = actionlint_1.6.25_windows_arm64.zip
+checksum = c949756b78d77164bd80f40d0443d1f7cf46fc4e704dbe89d0e42ae75020529c
+url = https://github.com/rhysd/actionlint/releases/download/v1.6.25/actionlint_1.6.25_windows_arm64.zip
+
 [cygwin-x86_64]
 file_name = actionlint_1.6.25_windows_amd64.zip
 checksum = 8f572a723f362f2ab05777aad0c85322fecf130e6ff0ca8ca0a6fb3a3414ac1b


### PR DESCRIPTION
Add checksums for actionlint Windows ARM64 build.

Cheers,
Jiri

![PTC logo email](https://user-images.githubusercontent.com/44769714/83034194-45548080-a038-11ea-9960-de502a30d89d.png)

**Jiri Hörner**
Senior Software Development Engineer

[jhoerner@ptc.com](mailto:jhoerner@ptc.com)
[ptc.com](http://www.ptc.com/)